### PR TITLE
Change version to be hard-coded

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ import { Hotjar } from 'astro-hotjar';
 ```
 
 ```html
-<Hotjar id="a1a4z5d6" version="6" />
+<Hotjar id="a1a4z5d6" />
 ```
 # astro-hotjar

--- a/src/hotjar.astro
+++ b/src/hotjar.astro
@@ -1,15 +1,14 @@
 ---
 export interface Props {
   id: string;
-  version: string;
 }
 
-const { id, version } = Astro.props;
+const { id } = Astro.props;
 ---
 <script id="astro-plugin-hotjar" define:vars={{id}}>
   (function(h,o,t,j,a,r){
       h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-      h._hjSettings={hjid: id,hjsv: version};
+      h._hjSettings={hjid: id,hjsv: 6};
       a=o.getElementsByTagName('head')[0];
       r=o.createElement('script');r.async=1;
       r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;


### PR DESCRIPTION
The version, a.k.a hjsv (Hotjar Snippet Version) is used to describe the "version" of the snippet code, and is not intended to be set by the user. The only time it should be changed is when the actual snippet code itself changes.

Setting it incorrectly will cause Hotjar to believe you're using a different snippet version than you are.